### PR TITLE
Feat: add prepared chunk to payment handler params

### DIFF
--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -57,7 +57,11 @@ export interface PaymentHandlerParams {
    * Alternative to `reject` that gives the user more control over the payment chunks they wish to reject.
    * If this method is called, the PaymentHandler callback will be called again for subsequent chunks with the same payment `id`.
    */
-  rejectSingleChunk: (message: string) => void
+  rejectSingleChunk: (message: string) => void,
+  /**
+   * Details about this prepared chunk; in the form of a parsed interledger packet.
+   */
+  prepare: IlpPacket.IlpPrepare
 }
 
 export interface PaymentReceived {
@@ -327,7 +331,8 @@ export class Receiver {
               record.rejectionMessage = message
               resolve()
               // TODO check that the message isn't too long
-            }
+            },
+            prepare
           }))
 
           // If the user didn't call the accept function, reject it

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -8,7 +8,7 @@ import * as constants from './constants'
 import { serializePskPacket, deserializePskPacket, PskPacket } from './encoding'
 import { dataToFulfillment, fulfillmentToCondition } from './condition'
 
-const DEFAULT_TRANSFER_TIMEOUT = 2000
+const DEFAULT_TRANSFER_TIMEOUT = 5000
 const STARTING_TRANSFER_AMOUNT = 1000
 const TRANSFER_INCREASE = 1.1
 const TRANSFER_DECREASE = 0.5

--- a/test/receiver.test.ts
+++ b/test/receiver.test.ts
@@ -356,6 +356,8 @@ describe('Receiver', function () {
       assert.typeOf(spy.args[0][0].reject, 'function')
       assert.typeOf(spy.args[0][0].acceptSingleChunk, 'function')
       assert.typeOf(spy.args[0][0].rejectSingleChunk, 'function')
+      assert.typeOf(spy.args[0][0].prepare, 'object')
+      assert.equal(spy.args[0][0].prepare.amount, '50')
       assert(Buffer.isBuffer(spy.args[0][0].id))
     })
 


### PR DESCRIPTION
For handling streaming payments, it's important to be able to see each individual chunk as you fulfill/reject it