### PR TITLE
Fix: finishedPromise may not be defined

### DIFF
--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -369,7 +369,7 @@ export class Receiver {
     record.received = record.received.plus(prepare.amount)
     if (record.received.gte(record.expected) || request.type === constants.TYPE_PSK2_LAST_CHUNK) {
       record.finished = true
-      record.finishedPromise.resolve({
+      record.finishedPromise && record.finishedPromise.resolve({
         id: request.paymentId,
         receivedAmount: record.received.toString(10),
         expectedAmount: record.expected.toString(10),


### PR DESCRIPTION
If the payment was completed in one chunk and `acceptSingleChunk` completed it,
then `finishedPromise` will be undefined. Currently, this behavior causes an
unhandled error as it tries to resolve the promise.